### PR TITLE
Do not automatically load the mysql2, instead explcitly require it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dalli'
 gem 'kgio'
 
 # just used for unsubscribes import
-gem 'mysql2'
+gem 'mysql2', :require => nil
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/lib/crm/action_kit.rb
+++ b/lib/crm/action_kit.rb
@@ -9,6 +9,8 @@ end
 
 class CRM::ActionKit
 
+  require 'mysql2'
+
   private
 
   def initialize(config)


### PR DESCRIPTION
in the one module that actually needs it. Doing so reduces the
memory footprint of the application and start-up time.

 Please enter the commit message for your changes. Lines starting
