### PR TITLE
Upgrade selenium-web-driver gem to fix false positive js error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       rails
     celluloid (0.14.1)
       timers (>= 1.0.0)
-    childprocess (0.3.9)
+    childprocess (0.4.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.0.9)
     columnize (0.3.6)
@@ -146,7 +146,7 @@ GEM
       multi_json (>= 1.3)
       rack-oauth2 (>= 0.14.4)
       tzinfo
-    ffi (1.6.0)
+    ffi (1.9.3)
     flot-rails (0.0.2)
       jquery-rails
     font-awesome-rails (3.2.1.3)
@@ -195,7 +195,7 @@ GEM
     mime-types (1.21)
     mocha (0.10.5)
       metaclass (~> 0.0.1)
-    multi_json (1.7.2)
+    multi_json (1.8.4)
     multi_xml (0.5.2)
     mysql2 (0.3.11)
     newrelic-redis (1.4.0)
@@ -293,7 +293,7 @@ GEM
     rubinius-actor (0.0.2)
       rubinius-core-api
     rubinius-core-api (0.0.1)
-    rubyzip (0.9.9)
+    rubyzip (1.1.0)
     sanitize (2.0.3)
       nokogiri (>= 1.4.4, < 1.6)
       nokogiri (>= 1.4.4, < 1.6)
@@ -302,10 +302,10 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    selenium-webdriver (2.31.0)
+    selenium-webdriver (2.39.0)
       childprocess (>= 0.2.5)
       multi_json (~> 1.0)
-      rubyzip
+      rubyzip (~> 1.0)
       websocket (~> 1.0.4)
     shoulda-matchers (1.4.2)
       activesupport (>= 3.0.0)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3,6 +3,7 @@
 --
 
 SET statement_timeout = 0;
+SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -1729,6 +1730,13 @@ CREATE INDEX index_referral_codes_on_member_id ON referrals USING btree (member_
 --
 
 CREATE INDEX index_sent_emails_on_clicked_at ON sent_emails USING btree (clicked_at);
+
+
+--
+-- Name: index_sent_emails_on_created_at_and_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_sent_emails_on_created_at_and_type ON sent_emails USING btree (created_at, type);
 
 
 --


### PR DESCRIPTION
During a fresh install of VictoryKit with an rbenv install of 2.0.0-p353, running rake returned 3 false positive selenium test suite errors. The selenium tests were failing with: 

```
     Selenium::WebDriver::Error::JavascriptError:
       waiting for evaluate.js load failed
```

Upgrading to the latest `selenium-web-driver` gem (from 2.31.0 to 2.39.0) fixes this. This was with FF25 on Mavericks, Ruby 2.0.0-p353 installed via rbenv.

There's also a missing index from db/structure.sql, feel free to update or ignore :)
